### PR TITLE
Initialize viewer with existing checkpoints

### DIFF
--- a/gui/checkpoint_viewer.py
+++ b/gui/checkpoint_viewer.py
@@ -54,7 +54,7 @@ class CheckpointViewer(tk.Toplevel):
         self.sort_ascending = True
 
         # Initialiseer met data
-        self.erase_and_sync()
+        self.populate_tree()
 
     def erase_and_sync(self):
         try:


### PR DESCRIPTION
## Summary
- show existing checkpoints on viewer init

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d395621a883208913caf62666da3c