### PR TITLE
Add configurable DB path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ The test suite uses **pytest**. After installing the dependencies and pytest, ru
 pytest
 ```
 
+## 🗄️ Database Path
+
+By default the SQLite database is stored at `checkpoints/checkpoints_chat.db`.
+Set the `DB_PATH` environment variable or create a `db_config.json` file in the
+project root to override this location:
+
+```json
+{
+  "DB_PATH": "/path/to/your.db"
+}
+```
+
 ## 📂 Project Structure
 
 ```text

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -10,7 +10,7 @@ import storage.manager as manager
 
 def setup_temp_db(tmp_path, monkeypatch):
     db_path = tmp_path / "test.db"
-    monkeypatch.setattr(manager, "DB_PATH", str(db_path))
+    monkeypatch.setenv("DB_PATH", str(db_path))
     manager.init_db()
     return db_path
 


### PR DESCRIPTION
## Summary
- add `get_db_path()` function to load DB path from environment or config file
- use `get_db_path()` for all SQLite connections
- update tests to set `DB_PATH` environment variable
- document database path override mechanism in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5e71e980832093cebc65dc6e69fe