### PR TITLE
Improve tree column sort indicators

### DIFF
--- a/gui/checkpoint_viewer.py
+++ b/gui/checkpoint_viewer.py
@@ -34,11 +34,21 @@ class CheckpointViewer(tk.Toplevel):
         main_frame.pack(padx=10, pady=10, fill=tk.BOTH, expand=True)
 
         # TreeView met kolommen
-        self.tree = ttk.Treeview(main_frame, columns=("checkpoint_id", "name", "type", "created_at"), show="headings")
-        self.tree.heading("checkpoint_id", text="ID", command=lambda: self.sort_tree("checkpoint_id"))
-        self.tree.heading("name", text="Naam", command=lambda: self.sort_tree("name"))
-        self.tree.heading("type", text="Type", command=lambda: self.sort_tree("type"))
-        self.tree.heading("created_at", text="Created At", command=lambda: self.sort_tree("created_at"))
+        self.tree = ttk.Treeview(
+            main_frame,
+            columns=("checkpoint_id", "name", "type", "created_at"),
+            show="headings",
+        )
+
+        self.heading_labels = {
+            "checkpoint_id": "ID",
+            "name": "Naam",
+            "type": "Type",
+            "created_at": "Created At",
+        }
+
+        for col, label in self.heading_labels.items():
+            self.tree.heading(col, text=label, command=lambda c=col: self.sort_tree(c))
 
         self.tree.column("checkpoint_id", width=120)
         self.tree.column("name", width=250)
@@ -88,8 +98,18 @@ class CheckpointViewer(tk.Toplevel):
         if self.sort_column == col:
             self.sort_ascending = not self.sort_ascending
         else:
+            # Reset vorige kolom label indien nodig
+            if self.sort_column in getattr(self, "heading_labels", {}):
+                prev_label = self.heading_labels[self.sort_column]
+                self.tree.heading(self.sort_column, text=prev_label)
             self.sort_column = col
             self.sort_ascending = True
+
+        arrow = "▲" if self.sort_ascending else "▼"
+        if col in getattr(self, "heading_labels", {}):
+            label = self.heading_labels[col]
+            self.tree.heading(col, text=f"{label} {arrow}")
+
         self.populate_tree()
 
     def delete_and_sync_selected(self):

--- a/storage/manager.py
+++ b/storage/manager.py
@@ -104,7 +104,17 @@ def get_all_checkpoints_from_db(order_by="id", ascending=True):
     if order_by not in ("id", "checkpoint_id", "type", "name", "created_at"):
         order_by = "id"
 
-    query = f"SELECT checkpoint_id, name, type, created_at FROM checkpoints ORDER BY {order_by} {order_dir}"
+    if order_by == "checkpoint_id":
+        order_field = "CAST(checkpoint_id AS INTEGER)"
+    elif order_by in ("name", "type"):
+        order_field = f"{order_by} COLLATE NOCASE"
+    else:
+        order_field = order_by
+
+    query = (
+        "SELECT checkpoint_id, name, type, created_at FROM checkpoints "
+        f"ORDER BY {order_field} {order_dir}"
+    )
     cursor.execute(query)
     rows = cursor.fetchall()
     conn.close()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -56,3 +56,22 @@ def test_save_and_get_checkpoint(tmp_path, monkeypatch):
 def test_get_checkpoint_json_by_id_none(tmp_path, monkeypatch):
     setup_temp_db(tmp_path, monkeypatch)
     assert manager.get_checkpoint_json_by_id("missing") is None
+
+
+def test_get_all_checkpoints_sorted_case_insensitive(tmp_path, monkeypatch):
+    setup_temp_db(tmp_path, monkeypatch)
+    checkpoints = [
+        {"id": "1", "type": "demo", "name": "alpha", "created_at": "2024-01-01"},
+        {"id": "2", "type": "demo", "name": "Bravo", "created_at": "2024-01-01"},
+        {"id": "3", "type": "demo", "name": "charlie", "created_at": "2024-01-01"},
+    ]
+    for cp in checkpoints:
+        manager.save_checkpoint(cp)
+
+    rows = manager.get_all_checkpoints_from_db(order_by="name", ascending=True)
+    names = [r[1] for r in rows]
+    assert names == ["alpha", "Bravo", "charlie"]
+
+    rows_desc = manager.get_all_checkpoints_from_db(order_by="name", ascending=False)
+    names_desc = [r[1] for r in rows_desc]
+    assert names_desc == ["charlie", "Bravo", "alpha"]


### PR DESCRIPTION
## Summary
- allow toggling sort indicators in `CheckpointViewer.sort_tree`
- store base column labels and update headers with ▲ or ▼ when sorting
- cast checkpoint_id to integer so IDs sort numerically
- make name and type sorting case-insensitive via `COLLATE NOCASE`
- test case-insensitive sorting of checkpoint names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d61165ef48320817dd0485b2258e2