### PR TITLE
Fix checkpoint import mutation

### DIFF
--- a/gui/checkpoint_viewer.py
+++ b/gui/checkpoint_viewer.py
@@ -151,21 +151,19 @@ class CheckpointViewer(tk.Toplevel):
         try:
             api_data = get_checkpoints()
             for cp in api_data:
-                mapped = cp.copy()
-                mapped["id"] = cp.get("ActionID")
-                mapped["name"] = cp.get("ActionName")
-                mapped["type"] = cp.get("ActionType")
+                cp_id = cp.get("ActionID")
+                name = cp.get("ActionName")
 
-                if checkpoint_exists(mapped["id"]):
+                if checkpoint_exists(cp_id):
                     overwrite = messagebox.askyesno(
                         "Overschrijven?",
-                        f"Checkpoint '{mapped['name']}' bestaat al. Overschrijven?",
+                        f"Checkpoint '{name}' bestaat al. Overschrijven?",
                         parent=self,
                     )
                     if not overwrite:
                         continue
 
-                save_checkpoint(mapped)
+                save_checkpoint(cp)
 
             self.populate_tree()
             messagebox.showinfo("Sync voltooid", "Checkpoints gesynchroniseerd.", parent=self)
@@ -183,7 +181,7 @@ class CheckpointViewer(tk.Toplevel):
                 else:
                     response = create_checkpoint(cp)
                 save_checkpoint(response)
-                mark_checkpoint_modified(response.get("id"), False)
+                mark_checkpoint_modified(response.get("id") or response.get("ActionID"), False)
 
             self.populate_tree()
             messagebox.showinfo(

--- a/storage/manager.py
+++ b/storage/manager.py
@@ -158,6 +158,10 @@ def save_checkpoint(checkpoint_data: dict, modified: bool = False):
     conn = sqlite3.connect(get_db_path())
     cursor = conn.cursor()
 
+    cp_id = checkpoint_data.get("id", checkpoint_data.get("ActionID"))
+    cp_type = checkpoint_data.get("type", checkpoint_data.get("ActionType"))
+    cp_name = checkpoint_data.get("name", checkpoint_data.get("ActionName"))
+
     cursor.execute(
         """
         INSERT INTO checkpoints (checkpoint_id, type, name, json, created_at, modified_local)
@@ -170,9 +174,9 @@ def save_checkpoint(checkpoint_data: dict, modified: bool = False):
             modified_local=excluded.modified_local
     """,
         (
-            checkpoint_data.get("id"),
-            checkpoint_data.get("type"),
-            checkpoint_data.get("name"),
+            cp_id,
+            cp_type,
+            cp_name,
             json.dumps(checkpoint_data),
             checkpoint_data.get("created_at", ""),
             int(modified),

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -75,3 +75,18 @@ def test_get_all_checkpoints_sorted_case_insensitive(tmp_path, monkeypatch):
     rows_desc = manager.get_all_checkpoints_from_db(order_by="name", ascending=False)
     names_desc = [r[1] for r in rows_desc]
     assert names_desc == ["charlie", "Bravo", "alpha"]
+
+
+def test_save_checkpoint_preserves_json(tmp_path, monkeypatch):
+    setup_temp_db(tmp_path, monkeypatch)
+    checkpoint = {
+        "ActionID": "42",
+        "ActionName": "demo",
+        "ActionType": "drive",
+        "RobotPose": "",
+        "ActionInfo": "",
+        "Metadata": "",
+    }
+    manager.save_checkpoint(checkpoint)
+    result = manager.get_checkpoint_json_by_id("42")
+    assert result == checkpoint


### PR DESCRIPTION
## Summary
- keep API JSON intact when saving checkpoints
- adjust viewer sync to avoid mutating JSON
- handle ActionID when marking modified
- test that save_checkpoint preserves the original JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d33873e1c8320950bee0439c9819f